### PR TITLE
Fixed compilation error on usleep

### DIFF
--- a/Examples/Monocular/mono_kitti.cc
+++ b/Examples/Monocular/mono_kitti.cc
@@ -26,6 +26,7 @@
 #include<iomanip>
 
 #include<opencv2/core/core.hpp>
+#include <unistd.h>
 
 #include"System.h"
 

--- a/Examples/Monocular/mono_tum.cc
+++ b/Examples/Monocular/mono_tum.cc
@@ -27,6 +27,7 @@
 #include<opencv2/core/core.hpp>
 
 #include<System.h>
+#include <unistd.h>
 
 using namespace std;
 

--- a/Examples/RGB-D/rgbd_tum.cc
+++ b/Examples/RGB-D/rgbd_tum.cc
@@ -27,6 +27,7 @@
 #include<opencv2/core/core.hpp>
 
 #include<System.h>
+#include <unistd.h>
 
 using namespace std;
 

--- a/Examples/Stereo/stereo_kitti.cc
+++ b/Examples/Stereo/stereo_kitti.cc
@@ -28,6 +28,7 @@
 #include<opencv2/core/core.hpp>
 
 #include<System.h>
+#include <unistd.h>
 
 using namespace std;
 

--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -24,6 +24,7 @@
 #include "Optimizer.h"
 
 #include<mutex>
+#include <unistd.h>
 
 namespace ORB_SLAM2
 {

--- a/src/LoopClosing.cc
+++ b/src/LoopClosing.cc
@@ -30,6 +30,7 @@
 
 #include<mutex>
 #include<thread>
+#include <unistd.h>
 
 
 namespace ORB_SLAM2

--- a/src/System.cc
+++ b/src/System.cc
@@ -25,6 +25,7 @@
 #include <thread>
 #include <pangolin/pangolin.h>
 #include <iomanip>
+#include <unistd.h>
 
 namespace ORB_SLAM2
 {

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -36,6 +36,7 @@
 #include<iostream>
 
 #include<mutex>
+#include <unistd.h>
 
 
 using namespace std;

--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -22,6 +22,7 @@
 #include <pangolin/pangolin.h>
 
 #include <mutex>
+#include <unistd.h>
 
 namespace ORB_SLAM2
 {


### PR DESCRIPTION
I got compilation error that usleep was not defined.
I am using c++11 on Ubuntu 14.04.

The problem was solved by including
#include <unistd.h>